### PR TITLE
Initial commit

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,4 +1,7 @@
 {:server {:hostname "0.0.0.0" :port 8080}
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
-            :queues {"election-notification-http-api.ok" {:exclusive false :durable true :auto-delete false}}}}
+            :queues {"election-notification-http-api.ok" {:exclusive false :durable true :auto-delete false}
+                     "election-notification-works.subscription.create" {:exclusive false :durable true :auto-delete false}
+                     "election-notification-works.subscription.read" {:exclusive false :durable true :auto-delete false}
+                     "election-notification-works.subscription.delete" {:exclusive false :durable true :auto-delete false}}}}

--- a/src/election_notification_http_api/channels.clj
+++ b/src/election_notification_http_api/channels.clj
@@ -4,7 +4,11 @@
 
 (defonce ok-requests (async/chan))
 (defonce ok-responses (async/chan))
+(defonce create-subscriptions (async/chan))
+(defonce read-subscriptions (async/chan))
+(defonce delete-subscriptions (async/chan))
 
 (defn close-all! []
-  (doseq [c [ok-requests ok-responses]]
+  (doseq [c [ok-requests ok-responses create-subscriptions read-subscriptions
+             delete-subscriptions]]
     (async/close! c)))

--- a/src/election_notification_http_api/election_notification_works.clj
+++ b/src/election_notification_http_api/election_notification_works.clj
@@ -1,0 +1,7 @@
+(ns election-notification-http-api.election-notification-works
+  (:require [kehaar.wire-up :as wire-up]
+            [election-notification-http-api.channels :as channels]))
+
+(def create-subscription (wire-up/async->fn channels/create-subscriptions))
+(def read-subscription (wire-up/async->fn channels/read-subscriptions))
+(def delete-subscription (wire-up/async->fn channels/delete-subscriptions))

--- a/src/election_notification_http_api/queue.clj
+++ b/src/election_notification_http_api/queue.clj
@@ -19,7 +19,27 @@
                               (config [:rabbitmq :queues "election-notification-http-api.ok"])
                               channels/ok-requests
                               channels/ok-responses)]
-          external-services []
+          external-services [(wire-up/external-service
+                              connection
+                              ""
+                              "election-notification-works.subscription.create"
+                              (config [:rabbitmq :queues "election-notification-works.subscription.create"])
+                              1000
+                              channels/create-subscriptions)
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "election-notification-works.subscription.read"
+                              (config [:rabbitmq :queues "election-notification-works.subscription.read"])
+                              1000
+                              channels/read-subscriptions)
+                             (wire-up/external-service
+                              connection
+                              ""
+                              "election-notification-works.subscription.delete"
+                              (config [:rabbitmq :queues "election-notification-works.subscription.delete"])
+                              1000
+                              channels/delete-subscriptions)]
           outgoing-events []]
 
       (wire-up/start-responder! channels/ok-requests

--- a/src/election_notification_http_api/service.clj
+++ b/src/election_notification_http_api/service.clj
@@ -8,13 +8,112 @@
             [pedestal-toolbox.params :refer :all]
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
-            [clojure.core.async :refer [chan go alt! timeout]]))
+            [clojure.core.async :refer [go alt! timeout]]
+            [clojure.tools.logging :as log]
+            [election-notification-http-api.election-notification-works :as en]))
 
 (def ping
   (interceptor
    {:enter
     (fn [ctx]
       (assoc ctx :response (ring-resp/response "OK")))}))
+
+(defn rabbit-error->http-status
+  [rabbit-error]
+  (case (:type rabbit-error)
+    :semantic 400
+    :validation 400
+    :server 500
+    :timeout 504
+    500))
+
+(defn rabbit-result->http-status
+  [rabbit-result]
+  ;; TODO: Figure out what we get back on reads w/o subscriptions so we can return 404
+  (case (:status rabbit-result)
+    :error (rabbit-error->http-status (:error rabbit-result))
+    500))
+
+(def response-timeout 10000)
+
+(def create-subscription
+  (interceptor
+   {:enter
+    (fn [ctx]
+      (let [user-id (-> ctx
+                        (get-in [:request :path-params :user-id])
+                        java.util.UUID/fromString)
+            medium (keyword (get-in ctx [:request :path-params :medium]))
+            response-chan (en/create-subscription {:user-id user-id
+                                                   :mediums #{medium}})]
+        (log/debug :in :create-subscription :enter
+                   "Creating subscription for user-id"
+                   user-id "and medium" medium)
+        (go
+          (let [result (alt! (timeout response-timeout) {:status :error
+                                                         :error {:type :timeout}}
+                             response-chan ([v] v))]
+            (if (= (:status result) :ok)
+              (let [subscription (:subscription result)]
+                (assoc ctx :response
+                       (ring-resp/response subscription)))
+              (let [http-status (rabbit-result->http-status result)]
+                (assoc ctx :response
+                       (-> result
+                           ring-resp/response
+                           (ring-resp/status http-status)))))))))}))
+
+(def read-subscription
+  (interceptor
+   {:enter
+    (fn [ctx]
+      (let [user-id (-> ctx
+                        (get-in [:request :path-params :user-id])
+                        java.util.UUID/fromString)
+            response-chan (en/read-subscription {:user-id user-id})]
+        (log/debug :in :read-subscription :enter
+                   "Reading subscription for user-id"
+                   user-id)
+        (go
+          (let [result (alt! (timeout response-timeout) {:status :error
+                                                         :error {:type :timeout}}
+                             response-chan ([v] v))]
+            (if (= (:status result) :ok)
+              (let [subscription (:subscription result)]
+                (assoc ctx :response
+                       (ring-resp/response subscription)))
+              (let [http-status (rabbit-result->http-status result)]
+                (assoc ctx :response
+                       (-> result
+                           ring-resp/response
+                           (ring-resp/status http-status)))))))))}))
+
+(def delete-subscription
+  (interceptor
+   {:enter
+    (fn [ctx]
+      (let [user-id (-> ctx
+                        (get-in [:request :path-params :user-id])
+                        java.util.UUID/fromString)
+            medium (keyword (get-in ctx [:request :path-params :medium]))
+            response-chan (en/delete-subscription {:user-id user-id
+                                                   :mediums #{medium}})]
+        (log/debug :in :delete-subscription :enter
+                   "Deleting subscription for user-id"
+                   user-id "and medium" medium)
+        (go
+          (let [result (alt! (timeout response-timeout) {:status :error
+                                                         :error {:type :timeout}}
+                             response-chan ([v] v))]
+            (if (= (:status result) :ok)
+              (let [subscription (:subscription result)]
+                (assoc ctx :response
+                       (ring-resp/response subscription)))
+              (let [http-status (rabbit-result->http-status result)]
+                (assoc ctx :response
+                       (-> result
+                           ring-resp/response
+                           (ring-resp/status http-status)))))))))}))
 
 (defroutes routes
   [[["/"
@@ -24,7 +123,10 @@
                                                        "application/transit+msgpack"
                                                        "application/json"
                                                        "text/plain"])]
-     ["/ping" {:get [:ping ping]}]]]])
+     ["/ping" {:get [:ping ping]}]
+     ["/subscriptions/:user-id" {:get [:read-subscription read-subscription]}
+      ["/:medium" {:put [:create-subscription create-subscription]
+                   :delete [:delete-subscription delete-subscription]}]]]]])
 
 (defn service []
   {::env :prod

--- a/test/election_notification_http_api/service_test.clj
+++ b/test/election_notification_http_api/service_test.clj
@@ -1,9 +1,15 @@
 (ns election-notification-http-api.service-test
-    (:require [election-notification-http-api.server :as server]
-              [clj-http.client :as http]
-              [clojure.edn :as edn]
-              [cognitect.transit :as transit]
-              [clojure.test :refer :all]))
+  (:require [election-notification-http-api.server :as server]
+            [election-notification-http-api.service :as service]
+            [election-notification-http-api.election-notification-works :as en]
+            [election-notification-http-api.channels :as channels]
+            [clj-http.client :as http]
+            [clojure.edn :as edn]
+            [cognitect.transit :as transit]
+            [clojure.test :refer :all]
+            [clojure.string :as str]
+            [clojure.core.async :as async])
+  (:import [java.io ByteArrayInputStream]))
 
 (def test-server-port 56303)
 
@@ -21,3 +27,255 @@
                              {:headers {:accept "text/plain"}})]
       (is (= 200 (:status response)))
       (is (= "OK" (:body response))))))
+
+(deftest create-subscription-test
+  (testing "PUT to /subscriptions/:user-id/email puts appropriate create message
+            on create-subscriptions channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id
+                                                      "email"])
+                                       {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!! channels/create-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:email}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= #{:email} (:mediums message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:email}}
+               (-> http-response :body edn/read-string))))))
+  (testing "PUT to /subscriptions/:user-id/email can respond with Transit"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id
+                                                      "email"])
+                                       {:headers {:accept "application/transit+json"}}))
+          [response-ch message] (async/alt!! channels/create-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:email}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            create-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= #{:email} (:mediums message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:email}} create-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/put (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id
+                                                      "email"])
+                                       {:headers {:accept "application/edn"}
+                                        :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/create-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [service/response-timeout 500]
+      (let [fake-user-id (java.util.UUID/randomUUID)
+            http-response-ch (async/thread
+                               (http/put (str/join "/" [root-url
+                                                        "subscriptions"
+                                                        fake-user-id
+                                                        "email"])
+                                         {:headers {:accept "application/edn"}
+                                          :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/create-subscriptions ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))
+
+(deftest delete-subscription-test
+  (testing "DELETE to /subscriptions/:user-id/sms puts appropriate delete message
+            on delete-subscriptions channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/delete (str/join "/" [root-url
+                                                         "subscriptions"
+                                                         fake-user-id
+                                                         "sms"])
+                                          {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!! channels/delete-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:sms}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= #{:sms} (:mediums message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:sms}}
+               (-> http-response :body edn/read-string))))))
+  (testing "DELETE to /subscriptions/:user-id/email can respond with Transit"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/delete (str/join "/" [root-url
+                                                         "subscriptions"
+                                                         fake-user-id
+                                                         "email"])
+                                          {:headers {:accept "application/transit+json"}}))
+          [response-ch message] (async/alt!! channels/delete-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:email}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            delete-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= #{:email} (:mediums message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:email}} delete-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/delete (str/join "/" [root-url
+                                                         "subscriptions"
+                                                         fake-user-id
+                                                         "email"])
+                                          {:headers {:accept "application/edn"}
+                                           :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/delete-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [service/response-timeout 500]
+      (let [fake-user-id (java.util.UUID/randomUUID)
+            http-response-ch (async/thread
+                               (http/delete (str/join "/" [root-url
+                                                           "subscriptions"
+                                                           fake-user-id
+                                                           "email"])
+                                            {:headers {:accept "application/edn"}
+                                             :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/delete-subscriptions ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))
+
+(deftest read-subscription-test
+  (testing "GET to /subscriptions/:user-id puts appropriate read message
+            on read-subscriptions channel"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id])
+                                       {:headers {:accept "application/edn"}}))
+          [response-ch message] (async/alt!! channels/read-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:sms :email}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:email :sms}}
+               (-> http-response :body edn/read-string))))))
+  (testing "GET to /subscriptions/:user-id can respond with Transit"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id])
+                                       {:headers {:accept "application/transit+json"}}))
+          [response-ch message] (async/alt!! channels/read-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :ok
+                              :subscription {:user-id fake-user-id
+                                             :mediums #{:email}}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)
+            transit-in (ByteArrayInputStream. (-> http-response
+                                                  :body
+                                                  (.getBytes "UTF-8")))
+            transit-reader (transit/reader transit-in :json)
+            read-data (transit/read transit-reader)]
+        (assert (not= http-response ::timeout))
+        (is (= fake-user-id (:user-id message)))
+        (is (= 200 (:status http-response)))
+        (is (= {:user-id fake-user-id, :mediums #{:email}} read-data)))))
+  (testing "error from backend service results in HTTP server error response"
+    (let [fake-user-id (java.util.UUID/randomUUID)
+          http-response-ch (async/thread
+                             (http/get (str/join "/" [root-url
+                                                      "subscriptions"
+                                                      fake-user-id])
+                                       {:headers {:accept "application/edn"}
+                                        :throw-exceptions false}))
+          [response-ch message] (async/alt!! channels/read-subscriptions ([v] v)
+                                             (async/timeout 1000) [nil ::timeout])]
+      (assert (not= message ::timeout))
+      (async/>!! response-ch {:status :error
+                              :error {:type :server}})
+      (let [http-response (async/alt!! http-response-ch ([v] v)
+                                       (async/timeout 1000) ::timeout)]
+        (assert (not= http-response ::timeout))
+        (is (= 500 (:status http-response))))))
+  (testing "no response from backend service results in HTTP gateway timeout error response"
+    (with-redefs [service/response-timeout 500]
+      (let [fake-user-id (java.util.UUID/randomUUID)
+            http-response-ch (async/thread
+                               (http/get (str/join "/" [root-url
+                                                        "subscriptions"
+                                                        fake-user-id])
+                                         {:headers {:accept "application/edn"}
+                                          :throw-exceptions false}))
+            [response-ch message] (async/alt!! channels/read-subscriptions ([v] v)
+                                               (async/timeout 1000) [nil ::timeout])]
+        (assert (not= message ::timeout))
+        (let [http-response (async/alt!! http-response-ch ([v] v)
+                                         (async/timeout 1000) ::timeout)]
+          (assert (not= http-response ::timeout))
+          (is (= 504 (:status http-response))))))))


### PR DESCRIPTION
This creates the initial version of election-notification-http-api to support subscribing and unsubscribing to/from election notifications.

It will need this [pull request](https://github.com/democracyworks/election-notification-works/pull/9) to be merged into election-notification-works for the GET /subscriptions/user-id endpoint to work.

I've tested it in the krakenstein and it created, deleted, and read back subscriptions like whoa.

[Pivotal card](https://www.pivotaltracker.com/story/show/99188246)