### PR TITLE
Add JVM_OPTS to Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ COPY . /usr/src/election-notification-http-api
 RUN lein with-profiles $env,test test
 RUN lein with-profile $env uberjar
 
-CMD ["java", "-XX:+UseG1GC", "-javaagent:resources/jars/com.newrelic.agent.java/newrelic-agent.jar", "-jar", "target/election-notification-http-api.jar"]
+CMD java ${JVM_OPTS:--XX:+UseG1GC} \
+    -javaagent:resources/jars/com.newrelic.agent.java/newrelic-agent.jar \
+    -jar target/election-notification-http-ap

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN lein with-profile $env uberjar
 
 CMD java ${JVM_OPTS:--XX:+UseG1GC} \
     -javaagent:resources/jars/com.newrelic.agent.java/newrelic-agent.jar \
-    -jar target/election-notification-http-ap
+    -jar target/election-notification-http-api.jar


### PR DESCRIPTION
Defaulted to -XX:+UseG1GC.

This is especially useful with [this krakenstein PR](https://github.com/democracyworks/krakenstein/pull/39) for constraining memory usage in dev.

If this looks good I'll apply it straight to master in the other http-api components.